### PR TITLE
docs: Update documentation to reflect usage of `uv run` command

### DIFF
--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -214,7 +214,7 @@ class Configuration:
 │       │   ├── debug.py         # Debug utilities
 │       │   └── logging.py       # Loguru configuration (JSON logging)
 {%- if python_package_command_line_name %}
-│       └── __main__.py          # Entry point for `python -m`
+│       └── __main__.py          # Entry point for `uv run python -m`
 {%- endif %}
 ├── tests/
 │   ├── conftest.py              # Pytest fixtures

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -5,7 +5,7 @@
 default: help
 	@echo
 	@echo 'Enable direnv in your shell to use the `make` command: `direnv allow`'
-	@echo 'Or use `python scripts/make ARGS` to run the commands/tasks directly.'
+	@echo 'Or use `uv run python scripts/make ARGS` to run the commands/tasks directly.'
 
 .DEFAULT_GOAL: default
 
@@ -37,4 +37,4 @@ actions = \
 
 .PHONY: $(actions)
 $(actions):
-	@python scripts/make "$@"
+	@uv run python scripts/make "$@"

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -12,6 +12,12 @@
 ## Installation
 
 ```bash
+uv add {{ python_package_distribution_name }}
+```
+
+Or with pip:
+
+```bash
 pip install {{ python_package_distribution_name }}
 ```
 

--- a/project/docs/{% if include_notebooks %}notebooks.md{% endif %}.jinja
+++ b/project/docs/{% if include_notebooks %}notebooks.md{% endif %}.jinja
@@ -39,9 +39,9 @@ make marimo tutorial                  # Interactive tutorial
 Or use marimo directly (without default flags):
 
 ```bash
-marimo edit notebooks/starter.py
-marimo run notebooks/starter.py
-python notebooks/starter.py           # Execute as script
+uv run marimo edit notebooks/starter.py
+uv run marimo run notebooks/starter.py
+uv run python notebooks/starter.py    # Execute as script
 ```
 
 ## Why marimo?
@@ -114,7 +114,7 @@ With `marimo[recommended]`:
 Use sandbox mode for reproducible notebooks:
 
 ```bash
-marimo edit --sandbox notebooks/analysis.py
+uv run marimo edit --sandbox notebooks/analysis.py
 ```
 
 Dependencies are tracked in the file header:
@@ -130,10 +130,10 @@ Dependencies are tracked in the file header:
 
 ```bash
 # Export to HTML report
-marimo export html notebooks/analysis.py -o report.html
+uv run marimo export html notebooks/analysis.py -o report.html
 
 # Export to Jupyter (if needed)
-marimo export ipynb notebooks/analysis.py -o analysis.ipynb
+uv run marimo export ipynb notebooks/analysis.py -o analysis.ipynb
 ```
 
 ## Resources
@@ -147,6 +147,6 @@ marimo export ipynb notebooks/analysis.py -o analysis.ipynb
 
 !!! tip "Run the Interactive Tutorial"
     ```bash
-    marimo tutorial intro
+    uv run marimo tutorial intro
     ```
     This launches an interactive tutorial in your browser to learn marimo's key concepts.

--- a/project/scripts/make.py.jinja
+++ b/project/scripts/make.py.jinja
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run python
 from __future__ import annotations
 
 import os

--- a/project/src/{{python_package_import_name}}/_internal/{% if python_package_command_line_name %}cli.py{% endif %}.jinja
+++ b/project/src/{{python_package_import_name}}/_internal/{% if python_package_command_line_name %}cli.py{% endif %}.jinja
@@ -3,7 +3,7 @@
 # You might be tempted to import things from `__main__` later,
 # but that will cause problems: the code will get executed twice:
 #
-# - When you run `python -m {{ python_package_import_name }}` python will execute
+# - When you run `uv run python -m {{ python_package_import_name }}` python will execute
 #   `__main__.py` as a script. That means there won't be any
 #   `{{ python_package_import_name }}.__main__` in `sys.modules`.
 # - When you import `__main__` it will get executed again (as a module) because
@@ -64,7 +64,7 @@ def get_parser() -> argparse.ArgumentParser:
 def main(args: list[str] | None = None) -> int:
     """Run the main program.
 
-    This function is executed when you type `{{ python_package_command_line_name }}` or `python -m {{ python_package_import_name }}`.
+    This function is executed when you type `{{ python_package_command_line_name }}` or `uv run python -m {{ python_package_import_name }}`.
 
     Parameters:
         args: Arguments passed from the command line.

--- a/project/src/{{python_package_import_name}}/{% if python_package_command_line_name %}__main__.py{% endif %}.jinja
+++ b/project/src/{{python_package_import_name}}/{% if python_package_command_line_name %}__main__.py{% endif %}.jinja
@@ -1,4 +1,4 @@
-"""Entry-point module, in case you use `python -m {{ python_package_import_name }}`.
+"""Entry-point module, in case you use `uv run python -m {{ python_package_import_name }}`.
 
 Why does this file exist, and why `__main__`? For more info, read:
 

--- a/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
+++ b/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
@@ -70,9 +70,9 @@ This means your notebooks will automatically track which packages they use (save
 You can also use marimo directly (without the default flags):
 
 ```bash
-marimo edit notebooks/my_notebook.py
-marimo run notebooks/starter.py
-python notebooks/starter.py           # Execute as script
+uv run marimo edit notebooks/my_notebook.py
+uv run marimo run notebooks/starter.py
+uv run python notebooks/starter.py    # Execute as script
 ```
 
 ### Sandbox Mode (Recommended)
@@ -80,7 +80,7 @@ python notebooks/starter.py           # Execute as script
 For reproducible notebooks with tracked dependencies:
 
 ```bash
-marimo edit --sandbox notebooks/my_notebook.py
+uv run marimo edit --sandbox notebooks/my_notebook.py
 ```
 
 This automatically tracks packages in the notebook's header:
@@ -156,13 +156,13 @@ Notebooks are pure Python — use your normal tools:
 
 ```bash
 # Lint notebooks
-ruff check notebooks/
+uv run ruff check notebooks/
 
 # Format notebooks
-ruff format notebooks/
+uv run ruff format notebooks/
 
 # Type check
-mypy notebooks/
+uv run mypy notebooks/
 ```
 
 ### Version Control
@@ -175,13 +175,13 @@ mypy notebooks/
 
 ```bash
 # Export to standalone HTML
-marimo export html notebooks/analysis.py -o report.html
+uv run marimo export html notebooks/analysis.py -o report.html
 
 # Export to Jupyter (for colleagues who need it)
-marimo export ipynb notebooks/analysis.py -o analysis.ipynb
+uv run marimo export ipynb notebooks/analysis.py -o analysis.ipynb
 
 # Export to markdown
-marimo export md notebooks/analysis.py -o analysis.md
+uv run marimo export md notebooks/analysis.py -o analysis.md
 ```
 
 ## Resources
@@ -195,7 +195,7 @@ marimo export md notebooks/analysis.py -o analysis.md
 
 ### Learning
 
-- [Interactive Tutorials](https://docs.marimo.io/getting_started/installation) — Run `marimo tutorial --help`
+- [Interactive Tutorials](https://docs.marimo.io/getting_started/installation) — Run `uv run marimo tutorial --help`
 - [YouTube Channel](https://www.youtube.com/@maraboroda) — Video tutorials and concept explanations
 - [Example Gallery](https://marimo.io/) — Browse community notebooks
 
@@ -265,10 +265,10 @@ Deploy notebooks as interactive web applications:
 
 ```bash
 # Local app
-marimo run notebooks/dashboard.py
+uv run marimo run notebooks/dashboard.py
 
 # With authentication
-marimo run notebooks/dashboard.py --token-password="secret"
+uv run marimo run notebooks/dashboard.py --token-password="secret"
 
 # Docker deployment
 docker run -p 8080:8080 -v $(pwd)/notebooks:/app ghcr.io/marimo-team/marimo

--- a/project/{% if include_notebooks %}notebooks{% endif %}/starter.py.jinja
+++ b/project/{% if include_notebooks %}notebooks{% endif %}/starter.py.jinja
@@ -221,7 +221,7 @@ def _(mo):
 
         ```bash
         # List all tutorials
-        marimo tutorial --help
+        uv run marimo tutorial --help
 
         # Export to HTML
         marimo export html notebook.py -o report.html
@@ -241,7 +241,7 @@ def _(mo):
         ---
 
         💡 **Tip**: This notebook is stored as a pure Python file.
-        You can lint it with `ruff check notebooks/` and format with `ruff format notebooks/`.
+        You can lint it with `uv run ruff check notebooks/` and format with `uv run ruff format notebooks/`.
         """
     )
     return


### PR DESCRIPTION
- Changed instances of `python` to `uv run python` in various documentation files, including README, notebooks, and Makefile.
- Updated entry point descriptions in `__main__.py` and CLI documentation to align with the new command structure.
- Enhanced instructions for running scripts and commands to improve clarity and consistency.