### PR TITLE
fix(tests): Release file lock in logging tests on Windows

### DIFF
--- a/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
+++ b/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
@@ -113,6 +113,8 @@ def test_configure_logging_with_file() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         log_file = Path(tmpdir) / "test.log"
         configure_logging(level="DEBUG", json_logs=True, log_file=log_file)
+        # Remove handlers to release file lock (required on Windows)
+        logger.remove()
 
 
 def test_configure_logging_file_with_human_readable() -> None:
@@ -120,6 +122,8 @@ def test_configure_logging_file_with_human_readable() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         log_file = Path(tmpdir) / "test.log"
         configure_logging(level="WARNING", json_logs=False, log_file=log_file)
+        # Remove handlers to release file lock (required on Windows)
+        logger.remove()
 
 
 def test_configure_logging_all_levels() -> None:


### PR DESCRIPTION
- Added logger removal in `test_configure_logging_with_file` and `test_configure_logging_file_with_human_readable` to ensure file locks are released on Windows systems.