### PR TITLE
docs: Update README and CLAUDE.md for marimo command changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 
 ### Additional Features (this fork)
 
-- **[marimo](https://marimo.io/) notebooks** support with `make marimo` commands
+- **[marimo](https://marimo.io/) notebooks** support (use `uv run marimo`)
 - **[loguru](https://github.com/Delgan/loguru)** for structured JSON logging
 - **CLAUDE.md** for AI assistant guidance
 - **Cursor IDE integration** via `.cursorrules` symlink (points to `CLAUDE.md`)

--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -22,10 +22,6 @@ make test           # Run test suite
 make format         # Auto-format code
 make docs           # Serve documentation locally
 make build          # Build source and wheel distributions
-{%- if include_notebooks %}
-make marimo edit    # Edit notebooks
-make marimo run     # Run notebook as app
-{%- endif %}
 ```
 
 ## Commit Message Convention
@@ -445,18 +441,22 @@ make check-docs     # Verify build
 This project uses [marimo](https://marimo.io/) for interactive notebooks.
 
 ```bash
-make marimo edit                    # Edit starter notebook (--sandbox --watch)
-make marimo edit notebooks/my.py    # Edit specific notebook
-make marimo run                     # Run starter as app
-make marimo run notebooks/my.py     # Run specific notebook as app
-make marimo new my_analysis         # Create new notebook
-make marimo convert old.ipynb       # Convert from Jupyter
-make marimo tutorial                # Run marimo tutorial
+uv run marimo edit notebooks/starter.py    # Edit starter notebook
+uv run marimo edit notebooks/my.py         # Edit specific notebook
+uv run marimo run notebooks/starter.py     # Run starter as app
+uv run marimo run notebooks/my.py          # Run specific notebook as app
+uv run marimo tutorial intro               # Run marimo tutorial
 ```
 
-**Default edit flags:**
+**Recommended edit flags:**
 - `--sandbox`: Track dependencies in notebook header for reproducibility
 - `--watch`: Auto-reload when imported modules change
+
+Example with flags:
+
+```bash
+uv run marimo edit --sandbox --watch notebooks/starter.py
+```
 
 See `notebooks/README.md` for guidelines.
 {% endif %}

--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -35,16 +35,22 @@ Run `make help` to see all the available actions!
 
 ## Notebooks
 
-This project uses [marimo](https://marimo.io/) for interactive notebooks. Use `make marimo` commands:
+This project uses [marimo](https://marimo.io/) for interactive notebooks:
 
 ```bash
-make marimo edit                    # Edit notebook (--sandbox --watch)
-make marimo edit notebooks/my.py    # Edit specific notebook
-make marimo run                     # Run notebook as app
-make marimo new my_analysis         # Create new notebook
+uv run marimo edit notebooks/starter.py    # Edit starter notebook
+uv run marimo edit notebooks/my.py         # Edit specific notebook
+uv run marimo run notebooks/starter.py     # Run notebook as app
+uv run marimo tutorial intro               # Interactive tutorial
 ```
 
-The `edit` command includes `--sandbox` (track dependencies) and `--watch` (auto-reload on module changes) by default.
+**Recommended flags** for `edit`:
+- `--sandbox`: Track dependencies in notebook header for reproducibility
+- `--watch`: Auto-reload when imported modules change
+
+```bash
+uv run marimo edit --sandbox --watch notebooks/my.py
+```
 
 See `notebooks/README.md` for more details.
 {% endif %}

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -26,9 +26,6 @@ actions = \
 	{%- endif %}
 	format \
 	help \
-	{%- if include_notebooks %}
-	marimo \
-	{%- endif %}
 	multirun \
 	publish \
 	release \

--- a/project/docs/{% if include_notebooks %}notebooks.md{% endif %}.jinja
+++ b/project/docs/{% if include_notebooks %}notebooks.md{% endif %}.jinja
@@ -8,40 +8,31 @@ This project uses [marimo](https://marimo.io/) for interactive notebooks — a *
 
 ## Quick Start
 
-Use `make marimo` for consistent notebook management:
-
 ```bash
-# Edit notebooks (includes --sandbox --watch by default)
-make marimo edit                      # Edit starter notebook
-make marimo edit notebooks/my.py      # Edit specific notebook
+# Edit notebooks
+uv run marimo edit notebooks/starter.py    # Edit starter notebook
+uv run marimo edit notebooks/my.py         # Edit specific notebook
 
 # Run as interactive app
-make marimo run                       # Run starter notebook
-make marimo run notebooks/my.py       # Run specific notebook
+uv run marimo run notebooks/starter.py     # Run starter notebook
+uv run marimo run notebooks/my.py          # Run specific notebook
 
-# Create new notebook
-make marimo new my_analysis           # Creates notebooks/my_analysis.py
-
-# Convert from Jupyter
-make marimo convert old.ipynb         # Convert Jupyter notebook
+# Execute as script
+uv run python notebooks/starter.py
 
 # Tutorial
-make marimo tutorial                  # Interactive tutorial
+uv run marimo tutorial intro               # Interactive tutorial
 ```
 
-### Default Edit Flags
-
-`make marimo edit` automatically includes:
+### Recommended Edit Flags
 
 - `--sandbox` — Track dependencies in notebook header for reproducibility
 - `--watch` — Auto-reload when imported modules change
 
-Or use marimo directly (without default flags):
+Example with recommended flags:
 
 ```bash
-uv run marimo edit notebooks/starter.py
-uv run marimo run notebooks/starter.py
-uv run python notebooks/starter.py    # Execute as script
+uv run marimo edit --sandbox --watch notebooks/my.py
 ```
 
 ## Why marimo?

--- a/project/scripts/make.py.jinja
+++ b/project/scripts/make.py.jinja
@@ -126,54 +126,6 @@ def vscode() -> None:
     """Configure VSCode to work on this project."""
     shutil.copytree("config/vscode", ".vscode", dirs_exist_ok=True)
 
-{% if include_notebooks %}
-# Default flags for marimo edit mode
-MARIMO_EDIT_FLAGS = ("--sandbox", "--watch")
-
-
-def marimo(action: str, *args: str) -> None:
-    """Run marimo commands for notebook management.
-
-    Parameters:
-        action: The marimo action (edit, run, new, convert, export, tutorial).
-        *args: Additional arguments passed to marimo.
-
-    Default flags for edit mode:
-        --sandbox: Track dependencies in notebook header for reproducibility.
-        --watch: Auto-reload when imported modules change.
-    """
-    valid_actions = {"edit", "run", "new", "convert", "export", "tutorial"}
-    if action not in valid_actions:
-        print(f"make: marimo: unknown action '{action}'", file=sys.stderr)
-        print(f"Valid actions: {', '.join(sorted(valid_actions))}", file=sys.stderr)
-        sys.exit(1)
-
-    # Default to notebooks directory for edit/run/new if no path specified
-    if action in {"edit", "run", "new"} and not args:
-        if action == "new":
-            print("make: marimo new: please specify a notebook name", file=sys.stderr)
-            print("Example: make marimo new my_notebook", file=sys.stderr)
-            sys.exit(1)
-        # Default to starter notebook for edit/run
-        args = ("notebooks/starter.py",)
-
-    # For 'new', automatically add notebooks/ prefix if not present
-    if action == "new" and args:
-        notebook_name = args[0]
-        if not notebook_name.startswith("notebooks/"):
-            notebook_name = f"notebooks/{notebook_name}"
-        if not notebook_name.endswith(".py"):
-            notebook_name = f"{notebook_name}.py"
-        args = (notebook_name, *args[1:])
-        # Use 'edit' to create new notebooks
-        action = "edit"
-
-    # Add default flags for edit mode (sandbox + watch)
-    if action == "edit":
-        args = (*MARIMO_EDIT_FLAGS, *args)
-
-    run("default", "marimo", action, *args)
-{% endif %}
 
 def main() -> int:
     """Main entry point."""
@@ -194,16 +146,6 @@ def main() -> int:
                       3.x                   Run a command in the virtual environment for Python 3.x.
                       clean                 Delete build artifacts and cache files.
                       vscode                Configure VSCode to work on this project.
-                    {%- if include_notebooks %}
-
-                    Notebook commands (marimo)
-                      marimo edit [FILE]    Edit a notebook with --sandbox --watch flags.
-                      marimo run [FILE]     Run a notebook as an app.
-                      marimo new NAME       Create a new notebook in notebooks/.
-                      marimo convert FILE   Convert a Jupyter notebook to marimo.
-                      marimo export ...     Export a notebook (html, ipynb, md).
-                      marimo tutorial       Run the marimo tutorial.
-                    {%- endif %}
                     """,
                 ),
                 flush=True,
@@ -254,14 +196,6 @@ def main() -> int:
             setup()
         elif cmd == "vscode":
             vscode()
-        {%- if include_notebooks %}
-        elif cmd == "marimo":
-            if not args:
-                print("make: marimo: missing action (edit, run, new, convert, export, tutorial)", file=sys.stderr)
-                return 1
-            marimo(args.pop(0), *args)
-            return 0
-        {%- endif %}
         elif cmd == "check":
             multirun("duty", "check-quality", "check-types", "check-docs")
             run("default", "duty", "check-api")

--- a/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
+++ b/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
@@ -28,52 +28,38 @@ uv pip install "marimo[recommended]"
 
 The `[recommended]` extra includes SQL support, AI completion, and additional features.
 
-### Make Commands
-
-Use `make marimo` for consistent notebook management:
+### Commands
 
 ```bash
-# Edit notebooks (includes --sandbox --watch by default)
-make marimo edit                      # Edit starter notebook
-make marimo edit notebooks/my.py      # Edit specific notebook
+# Edit notebooks
+uv run marimo edit notebooks/starter.py     # Edit starter notebook
+uv run marimo edit notebooks/my.py          # Edit specific notebook
 
 # Run as interactive app
-make marimo run                       # Run starter notebook
-make marimo run notebooks/my.py       # Run specific notebook
+uv run marimo run notebooks/starter.py      # Run starter notebook
+uv run marimo run notebooks/my.py           # Run specific notebook
 
-# Create new notebook
-make marimo new my_analysis           # Creates notebooks/my_analysis.py
-
-# Convert from Jupyter
-make marimo convert old.ipynb         # Convert Jupyter notebook
-
-# Export notebooks
-make marimo export html my.py -o report.html
+# Execute as script
+uv run python notebooks/starter.py
 
 # Tutorial
-make marimo tutorial                  # Run interactive tutorial
+uv run marimo tutorial intro                # Run interactive tutorial
 ```
 
-#### Default Edit Flags
-
-When you run `make marimo edit`, these flags are automatically included:
+### Recommended Edit Flags
 
 | Flag | Description |
 |------|-------------|
 | `--sandbox` | Track dependencies in notebook header for reproducibility |
 | `--watch` | Auto-reload when imported modules change |
 
-This means your notebooks will automatically track which packages they use (saved in the `# /// script` header), and any changes to your project's modules will trigger a reload.
-
-### Direct marimo Commands
-
-You can also use marimo directly (without the default flags):
+Example with recommended flags:
 
 ```bash
-uv run marimo edit notebooks/my_notebook.py
-uv run marimo run notebooks/starter.py
-uv run python notebooks/starter.py    # Execute as script
+uv run marimo edit --sandbox --watch notebooks/my.py
 ```
+
+This means your notebooks will automatically track which packages they use (saved in the `# /// script` header), and any changes to your project's modules will trigger a reload.
 
 ### Sandbox Mode (Recommended)
 

--- a/project/{% if include_notebooks %}notebooks{% endif %}/starter.py.jinja
+++ b/project/{% if include_notebooks %}notebooks{% endif %}/starter.py.jinja
@@ -46,20 +46,20 @@ def _(mo):
         r"""
         ## 🚀 Quick Start
 
-        Use `make marimo` for consistent notebook management:
-
         | Command | Description |
         |---------|-------------|
-        | `make marimo edit` | Edit notebook with `--sandbox --watch` |
-        | `make marimo edit notebooks/my.py` | Edit specific notebook |
-        | `make marimo run` | Run starter as interactive app |
-        | `make marimo new my_analysis` | Create new notebook |
-        | `make marimo convert old.ipynb` | Convert from Jupyter |
-        | `make marimo tutorial` | Interactive tutorial |
+        | `uv run marimo edit notebooks/starter.py` | Edit this notebook |
+        | `uv run marimo edit notebooks/my.py` | Edit specific notebook |
+        | `uv run marimo run notebooks/starter.py` | Run as interactive app |
+        | `uv run marimo tutorial intro` | Interactive tutorial |
 
-        **Default flags for edit mode:**
+        **Recommended flags for edit mode:**
         - `--sandbox`: Dependencies are tracked in the notebook header
         - `--watch`: Auto-reload when your project modules change
+
+        ```bash
+        uv run marimo edit --sandbox --watch notebooks/my.py
+        ```
         """
     )
     return


### PR DESCRIPTION
- Updated README.md to reflect new marimo command usage with `uv run` instead of `make marimo`.
- Revised CLAUDE.md.jinja to remove deprecated marimo commands and clarify recommended flags.
- Adjusted documentation in CONTRIBUTING.md.jinja and notebooks README files to align with the new command structure.