### PR TITLE
fix(config): Adjust Ruff configuration for notebook exclusion

### DIFF
--- a/project/config/ruff.toml.jinja
+++ b/project/config/ruff.toml.jinja
@@ -84,12 +84,15 @@ known-first-party = ["{{ python_package_import_name }}"]
 convention = "google"
 
 [format]
+{% if include_notebooks %}
 exclude = [
     "tests/fixtures/*.py",
-{% if include_notebooks %}
     "notebooks/*.py",  # Marimo notebooks are formatted automatically
-
-{% endif %}
 ]
+{% else %}
+exclude = [
+    "tests/fixtures/*.py",
+]
+{% endif %}
 docstring-code-format = true
 docstring-code-line-length = 80


### PR DESCRIPTION
- Updated ruff.toml.jinja to conditionally exclude notebooks from formatting based on the include_notebooks variable.
- Ensured that tests/fixtures are always excluded, while notebooks are only excluded if the variable is not set.