### PR TITLE
refactor(logging): Update logging imports to use loguru directly

### DIFF
--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -152,13 +152,16 @@ uv run marimo run notebooks/starter.py            # Run as app
 {% endif %}
 ## Logging
 
-Use `logger` from `_internal.logging` (not `loguru.logger` directly):
+Import `logger` directly from loguru (it's a singleton):
 
 ```python
-from {{ python_package_import_name }}._internal.logging import logger
+from loguru import logger
 
 logger.info("Action", user_id=123, action="login")  # Structured data as kwargs
 ```
+
+Use `configure_logging` from `_internal.logging` only to set up handlers.
+Example: `configure_logging(level="INFO", json_logs=False)`
 
 ## Key Files
 
@@ -188,4 +191,4 @@ logger.info("Action", user_id=123, action="login")  # Structured data as kwargs
 - ❌ Skip type hints
 - ❌ Relative imports
 - ❌ `print()` for debugging (use `logger`)
-- ❌ `loguru.logger` directly
+- ❌ `print()` for logging (use `logger`)

--- a/project/src/{{python_package_import_name}}/__init__.py.jinja
+++ b/project/src/{{python_package_import_name}}/__init__.py.jinja
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+from loguru import logger
+
 {% if python_package_command_line_name -%}
 from {{ python_package_import_name }}._internal.cli import get_parser, main
 {% endif -%}
-from {{ python_package_import_name }}._internal.logging import configure_logging, logger
+from {{ python_package_import_name }}._internal.logging import configure_logging
 
 {% if python_package_command_line_name -%}
 __all__: list[str] = ["configure_logging", "get_parser", "logger", "main"]

--- a/project/src/{{python_package_import_name}}/_internal/logging.py.jinja
+++ b/project/src/{{python_package_import_name}}/_internal/logging.py.jinja
@@ -29,7 +29,8 @@ def configure_logging(
         log_file: Optional file path to write logs to (in addition to stderr).
 
     Examples:
-        >>> from {{ python_package_import_name }}._internal.logging import configure_logging, logger
+        >>> from {{ python_package_import_name }}._internal.logging import configure_logging
+        >>> from loguru import logger
         >>> configure_logging(level="DEBUG", json_logs=True)
         >>> logger.info("Application started", user_id=123)
     """
@@ -66,4 +67,4 @@ def configure_logging(
         )
 
 
-__all__ = ["configure_logging", "logger"]
+__all__ = ["configure_logging"]

--- a/project/src/{{python_package_import_name}}/_internal/{% if python_package_command_line_name %}cli.py{% endif %}.jinja
+++ b/project/src/{{python_package_import_name}}/_internal/{% if python_package_command_line_name %}cli.py{% endif %}.jinja
@@ -15,8 +15,10 @@ import argparse
 import sys
 from typing import Any
 
+from loguru import logger
+
 from {{ python_package_import_name }}._internal import debug
-from {{ python_package_import_name }}._internal.logging import configure_logging, logger
+from {{ python_package_import_name }}._internal.logging import configure_logging
 
 _VERBOSE_DEBUG = 2  # -vv for DEBUG level
 

--- a/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
+++ b/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
@@ -9,10 +9,11 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from loguru import logger
 
 from {{ python_package_import_name }} import main
 from {{ python_package_import_name }}._internal import debug
-from {{ python_package_import_name }}._internal.logging import configure_logging, logger
+from {{ python_package_import_name }}._internal.logging import configure_logging
 
 # =============================================================================
 # CLI Tests


### PR DESCRIPTION
- Changed logger import to directly use loguru in various files, including CLAUDE.md.jinja, __init__.py.jinja, cli.py.jinja, and logging.py.jinja.
- Updated documentation in CLAUDE.md.jinja to reflect the new logging usage and configuration.
- Removed direct logger import from internal logging module to streamline logging setup.

Closes #21 