### PR TITLE
Add git config and env var fallbacks for author defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 - **[loguru](https://github.com/Delgan/loguru)** for structured JSON logging
 - **CLAUDE.md** for AI assistant guidance
 - **Cursor IDE integration** via `.cursorrules` symlink (points to `CLAUDE.md`)
-- **Library mode** (`is_library=true`): enables [Griffe](https://github.com/mkdocstrings/griffe) for API breaking change detection
+- **Library mode** (`is_library=false` by default): if `is_library` is set to `true`, enables [Griffe](https://github.com/mkdocstrings/griffe) for API breaking change detection
+- **Smart defaults** for author info:
+  - Git email defaults to your git config `user.email` value.
+  - Git username defaults to your git config `user.name` value.
 
 ## Quick setup and usage
 

--- a/copier.yml
+++ b/copier.yml
@@ -27,17 +27,16 @@ project_description:
 author_fullname:
   type: str
   help: Your full name
-  default: "Oral Ersoy Dokumaci"
 
 author_email:
   type: str
   help: Your email
-  default: "{{ git_user_email }}"
+  default: "{{ '' | git_user_email }}"
 
 author_username:
   type: str
   help: Your username (e.g. on GitHub)
-  default: oedokumaci
+  default: "{{ '' | git_user_name }}"
 
 repository_provider:
   type: str

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -60,20 +60,22 @@ The full name will appear as "author" in the project's metadata.
 ```
 Your email
 author_email? Format: str
-🎤 [None]: your@email.com
+🎤 [your@email.com]: 
 ```
 
 The email will appear as "author email" in the project's metadata.
+It defaults to your git config `user.email` value.
 
 ---
 
 ```
 Your username (e.g. on GitHub)
 author_username? Format: str
-🎤 [None]: your-username
+🎤 [your-username]: 
 ```
 
 The username you are using on the git repository provider.
+It defaults to your git config `user.name` value.
 
 ---
 


### PR DESCRIPTION
Just extended the existing extensions further so that when a user starts a new project, the default full name and GH username values will be populated with their own information