### PR TITLE
fix(template): Format cli.py and debug.py templates for ruff compliance

### DIFF
--- a/project/src/{{python_package_import_name}}/_internal/debug.py.jinja
+++ b/project/src/{{python_package_import_name}}/_internal/debug.py.jinja
@@ -79,7 +79,10 @@ def _get_debug_info() -> _Environment:
     """
     py_name, py_version = _interpreter_name_version()
     packages = ["{{ python_package_distribution_name }}"]
-    variables = ["PYTHONPATH", *[var for var in os.environ if var.startswith("{{ python_package_distribution_name.upper().replace("-", "_") }}")]]
+    variables = [
+        "PYTHONPATH",
+        *[var for var in os.environ if var.startswith("{{ python_package_distribution_name.upper().replace('-', '_') }}")],
+    ]
     return _Environment(
         interpreter_name=py_name,
         interpreter_version=py_version,


### PR DESCRIPTION
## Summary
- Break long lines in `cli.py.jinja` and `debug.py.jinja` templates to pass ruff format checks
- Fixes the CI failure where generated projects fail formatting checks

## Problem
The generated project's CI was failing because `cli.py` and `debug.py` had lines that exceeded ruff's line length limit.

## Test plan
- [x] Generated test project and verified `uvx ruff format --check src/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)