### PR TITLE
docs: Update installation instructions and add post-generation messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ and [Copier](https://github.com/copier-org/copier).
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv tool install copier --with copier-templates-extensions
+uvx copier --with copier-templates-extensions
 ```
 
 Then you can clone the repository, enter it and set it up with:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 ## Features
 
 - [uv](https://github.com/astral-sh/uv) setup, with pre-defined `pyproject.toml`
-- Pre-configured tools for code formatting, quality analysis and testing:
+- Pre-configured tools for code formatting, quality, and type checking:
   [ruff](https://github.com/charliermarsh/ruff),
-  [mypy](https://github.com/python/mypy)
+  [ty](https://github.com/astral-sh/ty)
 - Tests run with [pytest](https://github.com/pytest-dev/pytest) and plugins, with [coverage](https://github.com/nedbat/coveragepy) support
 - Documentation built with [MkDocs](https://github.com/mkdocs/mkdocs)
   ([Material theme](https://github.com/squidfunk/mkdocs-material)

--- a/copier.yml
+++ b/copier.yml
@@ -17,6 +17,9 @@ _skip_if_exists:
 
 _tasks:
 - "git init ."
+- "echo ''"
+- "echo 'Project successfully generated!'"
+- "echo 'Run `uvx --from taskipy task --list` to show the available tasks.'"
 
 # PROMPT --------------------------------
 project_name:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -15,10 +15,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv python install 3.12
 ```
 
-To install Copier, use [`uv`](https://docs.astral.sh/uv/) or [`pipx`](https://pipx.pypa.io/stable/):
+To install Copier, use [`uvx`](https://docs.astral.sh/uv/) or [`pipx`](https://pipx.pypa.io/stable/):
 
 ```bash
-uv tool install copier --with copier-templates-extensions
+uvx copier --with copier-templates-extensions
 ```
 
 ```bash


### PR DESCRIPTION
- Change `uv tool install copier` to `uvx copier` in installation instructions across multiple documentation files.
- Add post-generation messages in `copier.yml` to guide users on available tasks after project generation.
- Update README to reflect changes in tool names and enhance clarity on pre-configured tools.