### PR TITLE
fix(template): Handle missing classifier key in gen_credits.py template

### DIFF
--- a/project/scripts/gen_credits.py.jinja
+++ b/project/scripts/gen_credits.py.jinja
@@ -71,7 +71,7 @@ def _set_license(metadata: PackageMetadata) -> None:
     check_classifiers = license_name in ("UNKNOWN", "Dual License", "") or license_name.count("\n")
     if check_classifiers:
         license_names = []
-        for classifier in metadata["classifier"]:
+        for classifier in metadata.get("classifier", []):
             if classifier.startswith("License ::"):
                 license_names.append(classifier.rsplit("::", 1)[1].strip())
         license_name = " + ".join(license_names)


### PR DESCRIPTION
- Update the loop in gen_credits.py.jinja to safely access the 'classifier' key using .get() method, preventing potential KeyError when the key is absent.