### PR TITLE
fix: Add new test command options and update CI workflow

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -58,7 +58,10 @@ jobs:
       run: uvx --from taskipy task typecheck
 
     - name: Build documentation
-      run: uvx --from taskipy task docs_build
+      run: |
+        mkdir -p htmlcov
+        touch htmlcov/index.html
+        uvx --from taskipy task docs_build
 
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v5

--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -177,8 +177,8 @@ Run with `uvx --from taskipy task <name>`:
 | `format_check` | Check code formatting (CI) |
 | `lint_check` | Check linting (CI) |
 | `typecheck` | Run type checking |
-| `test` | Run test suite |
-| `test_cov` | Run tests with coverage |
+| `test` | Run tests with coverage |
+| `test_no_cov` | Run test suite (no coverage) |
 | `ci` | Run all CI checks (format, lint, typecheck, test) |
 | `docs` | Serve documentation locally |
 | `docs_build` | Build documentation (strict) |

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -94,8 +94,8 @@ fix = { cmd = "task format && task lint", help = "Format + lint auto-fix" }
 format_check = { cmd = "uvx ruff format --check {all}", help = "Check code formatting (CI)" }
 lint_check = { cmd = "uvx ruff check {all}", help = "Check linting (CI)" }
 typecheck = { cmd = "uvx ty check {src}", help = "Run type checking" }
-test = { cmd = "uv run pytest {tests}", help = "Run test suite" }
-test_cov = { cmd = "uv run pytest {tests} --cov={src} --cov-report=html --cov-report=term", help = "Run tests with coverage" }
+test = { cmd = "uv run pytest {tests} --cov={src} --cov-report=html --cov-report=term", help = "Run tests with coverage" }
+test_no_cov = { cmd = "uv run pytest {tests}", help = "Run test suite" }
 
 # CI: all checks in one command (read-only)
 ci = { cmd = "task format_check && task lint_check && task typecheck && task test", help = "Run all CI checks (format, lint, typecheck, test)" }


### PR DESCRIPTION
- Introduced `test_no_cov` command to run the test suite without coverage.
- Updated `test` command to include coverage reporting in the `pyproject.toml.jinja`.
- Enhanced CI workflow to create a directory for coverage reports before building documentation.