### PR TITLE
fix: Change default copyright license from ISC to MIT

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -82,7 +82,7 @@ copyright_date:
 copyright_license:
   type: str
   help: Your project's license
-  default: ISC
+  default: MIT
   choices:
     Academic Free License v3.0: AFL-3.0
     Apache License 2.0: Apache-2.0

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -144,15 +144,15 @@ copyright_license? Format: str
 (2) Apache License 2.0
 (3) Artistic License 2.0
 ...
-(22) ISC License
+(24) MIT License
 ...
 (32) The Unlicense
 (33) zlib License
-Choice [22]: 
+Choice [24]: 
 ```
 
 A license from [choosealicense.com](https://choosealicense.com/).
-It defaults to ISC License.
+It defaults to MIT License.
 
 ---
 


### PR DESCRIPTION
- Updated the default license in `copier.yml` to MIT.
- Revised documentation in `generate.md` to reflect the new default license choice and updated choice number.