### PR TITLE
feat: Add Claude Code skills to project template

### DIFF
--- a/project/.claude/skills/commit/SKILL.md
+++ b/project/.claude/skills/commit/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: commit
+description: Create well-structured git commits following conventional commit format. Use when the user asks to commit changes, create a commit, or save their work to git.
+---
+# Commit Skill
+
+Create commits following the project's conventional commit format.
+
+## Commit Format
+
+```
+<type>[(scope)]: Subject
+```
+
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `deps`
+
+**Changelog types:** `build`, `deps`, `feat`, `fix`, `refactor`
+
+## Process
+
+1. Run `git status` to see changes
+2. Run `git diff --staged` and `git diff` to understand changes
+3. Analyze all changes and draft commit message:
+   - Summarize the nature (feat, fix, refactor, etc.)
+   - Focus on "why" rather than "what"
+   - Keep subject under 72 characters
+4. Stage specific files (avoid `git add -A`)
+5. Create commit with conventional format
+6. Verify with `git status`
+
+## Guidelines
+
+- Never commit sensitive files (.env, credentials)
+- Stage specific files rather than using `git add -A`
+- One logical change per commit
+- Subject should complete: "If applied, this commit will..."

--- a/project/.claude/skills/fix/SKILL.md
+++ b/project/.claude/skills/fix/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fix
+description: Run code formatting and linting with auto-fix using ruff via taskipy. Use when the user asks to fix code style, format code, lint, or clean up their code.
+---
+# Fix Skill
+
+Auto-format and lint code using ruff via taskipy.
+
+## Commands
+
+```bash
+# Format + lint with auto-fix (recommended)
+uvx --from taskipy task fix
+
+# Format only
+uvx --from taskipy task format
+
+# Lint with auto-fix only
+uvx --from taskipy task lint
+
+# Check formatting without changes (CI mode)
+uvx --from taskipy task format_check
+
+# Check linting without changes (CI mode)
+uvx --from taskipy task lint_check
+```
+
+## What Gets Fixed
+
+**Formatting (ruff format):**
+- Consistent indentation
+- Line length (120 chars max)
+- Quote style normalization
+- Trailing whitespace
+
+**Linting (ruff check --fix):**
+- Import sorting and organization
+- Unused imports removal
+- Simple code improvements
+- PEP 8 compliance
+
+## Process
+
+1. Run `uvx --from taskipy task fix`
+2. Review any remaining issues that couldn't be auto-fixed
+3. Manually address unfixable issues
+4. Run again to verify clean output
+
+## Configuration
+
+Ruff configuration is in `config/ruff.toml`:
+- Line length: 120
+- Target Python version matches project
+- Google-style docstrings
+- Absolute imports only

--- a/project/.claude/skills/pr/SKILL.md
+++ b/project/.claude/skills/pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pr
+description: Create GitHub pull requests with proper formatting and descriptions. Use when the user asks to create a PR, open a pull request, or submit their changes for review.
+---
+# Pull Request Skill
+
+Create well-structured GitHub pull requests.
+
+## Process
+
+1. Check current branch state:
+   - `git status` for uncommitted changes
+   - `git log origin/main..HEAD` for commits to include
+   - `git diff main...HEAD` for full diff
+2. Analyze ALL commits (not just the latest)
+3. Draft PR title and description:
+   - Title: Under 70 characters, descriptive
+   - Summary: 1-3 bullet points
+   - Test plan: How to verify changes
+4. Push branch and create PR
+
+## PR Format
+
+```markdown
+## Summary
+- Bullet point describing main change
+- Additional changes if applicable
+
+## Test plan
+- [ ] How to test the changes
+- [ ] Expected outcomes
+```
+
+## Commands
+
+```bash
+# Push branch
+git push -u origin <branch-name>
+
+# Create PR
+gh pr create --title "Title" --body "Body"
+```
+
+## Guidelines
+
+- Keep PR title short and descriptive
+- Reference related issues with #number
+- Include test plan for reviewers
+- One logical change per PR when possible

--- a/project/.claude/skills/review/SKILL.md
+++ b/project/.claude/skills/review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: review
+description: Review code for issues, best practices, and improvements. Use when the user asks for a code review, wants feedback on their code, or asks you to check their implementation.
+---
+# Review Skill
+
+Perform code review focusing on quality, correctness, and maintainability.
+
+## Review Checklist
+
+### Correctness
+- Logic errors or edge cases
+- Error handling coverage
+- Type safety and null checks
+
+### Code Quality (SOLID + Clean Code)
+- **Single Responsibility**: One reason to change per class/function
+- **Open/Closed**: Open for extension, closed for modification
+- **Liskov Substitution**: Subtypes substitutable for base types
+- **Interface Segregation**: Specific interfaces over general ones
+- **Dependency Inversion**: Depend on abstractions
+- DRY, YAGNI, meaningful names, Boy Scout Rule
+- Functions: Small (<20 lines), do one thing, few args (0-2)
+- No side effects, appropriate abstraction level
+
+### Style Compliance
+- Type hints on all functions/methods
+- Google-style docstrings
+- Absolute imports only
+- Line length under 120 chars
+
+### Testing
+- Tests cover new functionality
+- Tests verify behavior, not implementation
+- Edge cases tested
+- No flaky tests
+
+### Security
+- No hardcoded secrets
+- Input validation at boundaries
+- Safe handling of user data
+
+## Process
+
+1. Read the code to understand its purpose
+2. Run through the review checklist
+3. Identify issues by category:
+   - **Critical**: Bugs, security issues
+   - **Major**: Design problems, missing tests
+   - **Minor**: Style, naming, documentation
+4. Provide actionable feedback with specific suggestions
+5. Note positive aspects of the code
+
+## Output Format
+
+```markdown
+## Code Review
+
+### Summary
+Brief overview of the code's purpose and quality.
+
+### Critical Issues
+- Issue description and location
+- Suggested fix
+
+### Suggestions
+- Improvement opportunities
+- Alternative approaches
+
+### Positive Notes
+- Well-done aspects
+```

--- a/project/.claude/skills/test/SKILL.md
+++ b/project/.claude/skills/test/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: test
+description: Run the project test suite using taskipy. Use when the user asks to run tests, check if tests pass, verify their changes, or test specific functionality.
+---
+# Test Skill
+
+Run the project's test suite with pytest via taskipy.
+
+## Commands
+
+```bash
+# Run full test suite with coverage
+uvx --from taskipy task test
+
+# Run tests without coverage (faster)
+uvx --from taskipy task test_no_cov
+
+# Run specific test file
+uv run pytest tests/test_specific.py
+
+# Run specific test function
+uv run pytest tests/test_file.py::test_function
+
+# Run tests matching pattern
+uv run pytest -k "pattern"
+
+# Run with verbose output
+uv run pytest -v
+```
+
+## Process
+
+1. Run the appropriate test command
+2. Analyze test output for failures
+3. If failures occur:
+   - Identify the failing test(s)
+   - Read the test code to understand expectations
+   - Fix the issue in the source code
+   - Re-run to verify the fix
+
+## Coverage
+
+Test coverage reports are generated automatically with `task test`. The project maintains coverage thresholds defined in `config/pytest.ini`.
+
+## TDD (Test-Driven Development)
+
+**Three Laws:** (1) No production code without a failing test. (2) Write only enough test to fail. (3) Write only enough code to pass.
+
+**Cycle:** Red -> Green -> Refactor -> Repeat
+
+**FIRST:** **F**ast, **I**ndependent, **R**epeatable, **S**elf-validating, **T**imely
+
+## Guidelines
+
+- Test behavior, not implementation
+- Run tests after making changes
+- Write tests for new functionality
+- Use fixtures for common setup

--- a/project/.claude/skills/{% if include_notebooks %}jupyter-to-marimo{% endif %}/SKILL.md
+++ b/project/.claude/skills/{% if include_notebooks %}jupyter-to-marimo{% endif %}/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: jupyter-to-marimo
+description: Convert Jupyter notebooks (.ipynb) to marimo notebooks (.py). Use when the user wants to migrate or convert a Jupyter notebook to marimo format.
+---
+# Jupyter to Marimo Conversion
+
+Convert Jupyter notebooks to marimo format.
+
+## Process
+
+**ALWAYS run the CLI conversion first before reading any files.** Converted Python files are much smaller than raw `.ipynb` JSON, saving tokens.
+
+### Step 1: Convert
+
+```bash
+uvx marimo convert <notebook.ipynb> -o <notebook.py>
+```
+
+### Step 2: Validate
+
+```bash
+uvx marimo check <notebook.py>
+```
+
+Fix any reported issues.
+
+### Step 3: Clean Up
+
+- Verify metadata block includes all required packages
+- Remove Jupyter artifacts: `display()` calls, magic commands (`%`, `!`)
+- Ensure final cell expressions are displayable (not indented/conditional)
+- Replace ipywidgets with marimo equivalents:
+  - `ipywidgets.IntSlider` → `mo.ui.slider()`
+  - `ipywidgets.Dropdown` → `mo.ui.dropdown()`
+  - `ipywidgets.Text` → `mo.ui.text()`
+- Add `EnvConfig` widget if environment variables are needed
+
+### Step 4: Final Verification
+
+```bash
+uvx marimo check <notebook.py>
+```
+
+Confirm no errors were introduced during cleanup.

--- a/project/.claude/skills/{% if include_notebooks %}marimo-notebook{% endif %}/SKILL.md
+++ b/project/.claude/skills/{% if include_notebooks %}marimo-notebook{% endif %}/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: marimo-notebook
+description: Write marimo notebooks in Python files with proper format and best practices. Use when creating or editing marimo notebooks, or when the user asks about marimo patterns.
+---
+# Marimo Notebook Skill
+
+Write marimo notebooks in Python files following best practices.
+
+## Running Notebooks
+
+```bash
+uv run <notebook.py>                    # Script mode (testing)
+uv run marimo run <notebook.py>         # Interactive viewing
+uv run marimo edit <notebook.py>        # Interactive editing
+```
+
+## Script Mode Detection
+
+```python
+if mo.app_meta().mode == "script":
+    # CLI execution
+else:
+    # Browser execution
+```
+
+## Key Principle
+
+**Show all UI elements always. Only change the data source in script mode.**
+
+```python
+# GOOD: Always create widget, switch data source
+slider = mo.ui.slider(1, 100, value=50)
+data = default_data if mo.app_meta().mode == "script" else load_data(slider.value)
+
+# BAD: Conditional widget creation
+if mo.app_meta().mode != "script":
+    slider = mo.ui.slider(1, 100)
+```
+
+## Common Mistakes
+
+**Don't guard cells with `if` statements.** Marimo's reactivity handles dependencies. Guards prevent output rendering.
+
+**Don't use try/except for control flow.** Only catch specific, expected exceptions.
+
+**Cell output:** Only the final expression renders. Use ternary operators, not indented conditionals.
+
+## Best Practices
+
+- Prefix loop variables with underscore (`_name`, `_model`) to avoid cell conflicts
+- Use `pathlib.Path` over `os.path`
+- Use PEP 723 format for dependencies in file headers
+- Run `uvx marimo check <notebook.py>` before delivery

--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -27,101 +27,31 @@ uvx --from taskipy task docs     # Serve docs locally
 
 1. **Explore** - Read relevant code first
 2. **Plan** - Ask clarifying questions for architectural changes
-3. **Test First** - Write failing test (TDD)
-4. **Code** - Minimal code to pass test
-5. **Refactor** - Clean up, keep tests green
-6. **Verify** - `uvx --from taskipy task fix && uvx --from taskipy task ci`
+3. **Test First** - Write failing test, then minimal code to pass, then refactor
+4. **Verify** - `uvx --from taskipy task fix && uvx --from taskipy task ci`
 
 **Ask before:** Adding dependencies, changing public API, modifying structure.
-
-## Clean Code (Uncle Bob)
-
-### SOLID Principles
-
-| Principle | Description |
-|-----------|-------------|
-| **S**ingle Responsibility | One reason to change |
-| **O**pen/Closed | Open for extension, closed for modification |
-| **L**iskov Substitution | Subtypes substitutable for base types |
-| **I**nterface Segregation | Specific interfaces > general interfaces |
-| **D**ependency Inversion | Depend on abstractions |
-
-### Guidelines
-
-- **Functions**: Small (<20 lines), do one thing, few args (0-2), no side effects
-- **Classes**: Small, cohesive, encapsulated
-- **General**: DRY, YAGNI, meaningful names, Boy Scout Rule
-
-## TDD (Test-Driven Development)
-
-**Uncle Bob's Three Laws:**
-1. No production code without a failing test
-2. Write only enough test to fail
-3. Write only enough code to pass
-
-**Cycle:** Red -> Green -> Refactor -> Repeat
-
-**Test behavior, not implementation.** Tests verify *what* code does, not *how*.
-
-**FIRST:** **F**ast, **I**ndependent, **R**epeatable, **S**elf-validating, **T**imely
 
 ## Code Style
 
 ### Required in Every File
 
 ```python
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 ```
 
-### Type Hints (Mandatory)
-
-Every function, method, and variable MUST have type hints.
-
-### Docstrings (Google Style)
-
-```python
-def calculate(prices: list[float], *, tax: float = 0.0) -> float:
-    """Calculate total with tax.
-
-    Parameters:
-        prices: Item prices.
-        tax: Tax rate as decimal.
-
-    Returns:
-        Final total.
-    """
-```
-
-### Ruff Config
-
-- Line length: 120
-- Target: Python {{ python_version }}+
-- Docstrings: Google convention
-- Imports: Absolute only
-
-## Commit Messages
-
-**Format:** `<type>[(scope)]: Subject`
-
-**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `deps`
-
-**Examples:**
-```
-feat: Add user authentication
-fix(parser): Handle empty input
-```
-
-**Changelog types:** `build`, `deps`, `feat`, `fix`, `refactor`
+- **Type hints**: Mandatory on all functions, methods, and variables
+- **Docstrings**: Google style
+- **Ruff**: Line length 120, Python {{ python_version }}+, absolute imports only
 
 ## Project Structure
 
 ```
 {{ repository_name }}/
+├── .claude/skills/       # Claude Code skills
 ├── src/{{ python_package_import_name }}/
 │   ├── __init__.py       # Public API
 │   ├── __main__.py       # Module entry point (run via `task run`)
@@ -163,29 +93,21 @@ logger.info("Action", user_id=123, action="login")  # Structured data as kwargs
 Use `configure_logging` from `_internal.logging` only to set up handlers.
 Example: `configure_logging(level="INFO", json_logs=False)`
 
-## Available Tasks
+## Skills
 
-Run with `uvx --from taskipy task <name>`:
+Claude Code skills are available in `.claude/skills/`. Invoke with `/skill-name`:
 
-| Task | Description |
-|------|-------------|
-| `run` | Run module entrypoint |
-| `setup` | Install dependencies |
-| `format` | Format code (writes changes) |
-| `lint` | Lint and auto-fix (writes changes) |
-| `fix` | Format + lint auto-fix |
-| `format_check` | Check code formatting (CI) |
-| `lint_check` | Check linting (CI) |
-| `typecheck` | Run type checking |
-| `test` | Run tests with coverage |
-| `test_no_cov` | Run test suite (no coverage) |
-| `ci` | Run all CI checks (format, lint, typecheck, test) |
-| `docs` | Serve documentation locally |
-| `docs_build` | Build documentation (strict) |
-| `changelog` | Update changelog |
-| `clean` | Delete build artifacts and caches |
-| `profile` | Profile module with Scalene |
-| `profile_memory` | Profile module memory with Memray |
+| Skill | Description |
+|-------|-------------|
+| `/commit` | Create well-structured git commits |
+| `/pr` | Create GitHub pull requests |
+| `/test` | Run the test suite |
+| `/fix` | Auto-format and lint code |
+| `/review` | Perform code review |
+{%- if include_notebooks %}
+| `/marimo-notebook` | Write marimo notebooks properly |
+| `/jupyter-to-marimo` | Convert Jupyter notebooks to marimo |
+{%- endif %}
 
 ## Key Files
 
@@ -195,24 +117,3 @@ Run with `uvx --from taskipy task <name>`:
 | `config/ruff.toml` | Linting rules |
 | `config/pytest.ini` | Test configuration |
 | `.pre-commit-config.yaml` | Pre-commit hooks |
-
-## Do's and Don'ts
-
-**DO:**
-- Write tests FIRST (TDD)
-- Keep changes small and modular
-- Test behavior, not implementation
-- Type hints on everything
-- Google-style docstrings
-- `from __future__ import annotations` in every file
-- Absolute imports only
-- Run `uvx --from taskipy task fix && uvx --from taskipy task ci`
-
-**DON'T:**
-- Production code without failing test
-- Test implementation details
-- Push/release/deploy (user handles)
-- Skip type hints
-- Relative imports
-- `print()` for debugging (use `logger`)
-- `print()` for logging (use `logger`)


### PR DESCRIPTION
Add seven skills for Claude Code users in `.claude/skills/`:

Core skills (always included):
- /commit: Create well-structured git commits
- /pr: Create GitHub pull requests
- /test: Run the test suite with TDD guidance
- /fix: Auto-format and lint code with ruff
- /review: Perform code review with SOLID principles

Marimo skills (when include_notebooks=true):
- /marimo-notebook: Write marimo notebooks properly
- /jupyter-to-marimo: Convert Jupyter notebooks to marimo

Also slimmed down CLAUDE.md.jinja by moving detailed content (SOLID
principles, TDD laws, commit format, tasks table) into their respective
skills, keeping only essential project context always loaded.

Closes #61