### PR TITLE
fix: Replace _internal imports with public API in docs and AI guidance

### DIFF
--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -91,8 +91,8 @@ if TYPE_CHECKING:
 └── pyproject.toml        # Metadata, dependencies, and tasks
 ```
 
-- **Public API**: Exports in `__init__.py`
-- **Internal**: `_internal/` - not for external use
+- **Public API**: Exports in `__init__.py` — always import from here (e.g., `from {{ python_package_import_name }} import configure_logging`)
+- **Internal**: `_internal/` - private implementation, never import from `_internal` directly
 - **CLI**: `__main__.py` entry point calls `_internal/cli.py`
 {% if include_notebooks %}
 ## Notebooks
@@ -115,7 +115,7 @@ from loguru import logger
 logger.info("Action", user_id=123, action="login")  # Structured data as kwargs
 ```
 
-Use `configure_logging` from `_internal.logging` only to set up handlers.
+Use `configure_logging` (from `{{ python_package_import_name }}`) to set up handlers.
 Example: `configure_logging(level="INFO", json_logs=False)`
 
 ## Skills

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -23,7 +23,7 @@ pip install git+https://{{ repository_provider }}/{{ repository_namespace }}/{{ 
 ## Logging
 
 - Uses [loguru](https://github.com/Delgan/loguru) with JSON output to stderr by default (no log file is written unless you ask for one).
-- Programmatic control: `from {{ python_package_import_name }}._internal.logging import configure_logging` to customize level, JSON/human format, and optional `log_file`.
+- Programmatic control: `from {{ python_package_import_name }} import configure_logging` to customize level, JSON/human format, and optional `log_file`.
 
 ## Developer Workflow
 

--- a/project/src/{{python_package_import_name}}/_internal/logging.py.jinja
+++ b/project/src/{{python_package_import_name}}/_internal/logging.py.jinja
@@ -29,7 +29,7 @@ def configure_logging(
         log_file: Optional file path to write logs to (in addition to stderr).
 
     Examples:
-        >>> from {{ python_package_import_name }}._internal.logging import configure_logging
+        >>> from {{ python_package_import_name }} import configure_logging
         >>> from loguru import logger
         >>> configure_logging(level="DEBUG", json_logs=True)
         >>> logger.info("Application started", user_id=123)


### PR DESCRIPTION
Documentation and AI guidance (CLAUDE.md, README.md, docstrings) were
directing users and AI assistants to import from `_internal` directly,
even though `configure_logging` and `main` are re-exported in `__init__.py`.
This caused AI to overuse `_internal` imports throughout generated projects.

Closes #59