### PR TITLE
fix: Claude/review pr 63

### DIFF
--- a/docs/work.md
+++ b/docs/work.md
@@ -59,7 +59,7 @@ and [taskipy](https://github.com/taskipy/taskipy) for task running.
 
 ## Git Repository
 
-This project uses dynamic versioning based on Git tags. The git repository is automatically initialized when you generate the project.
+The version is managed via `__version__` in `src/your_package/__init__.py` (read by [hatch](https://hatch.pypa.io/)). The git repository is automatically initialized when you generate the project.
 
 To add remote, you can do the following:                                        
 
@@ -191,8 +191,7 @@ The typical development workflow is:
 git switch -c feat/my-feature
 
 # 2. Write code and tests
-<write code in src/your_package>
-<write tests in tests/>
+# (edit files in src/your_package and tests/)
 
 # 3. Run your application
 uvx --from taskipy task run
@@ -230,11 +229,9 @@ git pull
 # 2. Update the changelog (auto-determines version from commits)
 uvx --from taskipy task changelog
 
-# 3. Review the generated changelog
-<review CHANGELOG.md, edit if needed>
+# 3. Review the generated changelog, edit if needed
 
-# 4. Update the version in src/your_package/__init__.py
-<edit __version__ = "X.Y.Z" to match the changelog version>
+# 4. Update __version__ in src/your_package/__init__.py (hatch reads version from here)
 
 # 5. Commit the release directly to main
 git add .
@@ -377,7 +374,7 @@ Scope and body are optional. Type can be:
 
 ## Releases
 
-See the [Releasing](#releasing) section above for the full step-by-step workflow.
+See the [Releasing](#releasing) section under Workflow for a detailed step-by-step guide.
 
 In short:
 

--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -37,7 +37,7 @@ uvx --from taskipy task changelog    # Update changelog (for releases)
 
 ```bash
 git switch -c feat/my-feature             # 1. Create feature branch
-<write code and tests>                    # 2. Implement changes
+# write code and tests                    # 2. Implement changes
 uvx --from taskipy task fix               # 3. Auto-format + lint fix
 uvx --from taskipy task ci                # 4. Run all checks
 git add . && git commit -m "feat: ..."    # 5. Commit (Angular convention)
@@ -51,7 +51,7 @@ gh pr create                              # 8. Create pull request
 ```bash
 git checkout main && git pull                           # 1. Update main
 uvx --from taskipy task changelog                       # 2. Update CHANGELOG.md
-# edit __version__ in src/{{ python_package_import_name }}/__init__.py
+# update __version__ in src/{{ python_package_import_name }}/__init__.py (hatch reads version from here)
 git add . && git commit -m "chore: Release vX.Y.Z"     # 3. Commit release
 git push && git tag vX.Y.Z && git push --tags           # 4. Tag and push
 gh release create vX.Y.Z --generate-notes               # 5. GitHub release

--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -10,7 +10,7 @@ Fork and clone the repository, then:
 
 ```bash
 cd {{ repository_name }}
-make setup
+uvx --from taskipy task setup
 ```
 
 > NOTE: If it fails for some reason, you'll need to install [uv](https://github.com/astral-sh/uv) manually.
@@ -21,11 +21,11 @@ make setup
 > curl -LsSf https://astral.sh/uv/install.sh | sh
 > ```
 >
-> Now you can try running `make setup` again, or simply `uv sync`.
+> Now you can try running `uvx --from taskipy task setup` again, or simply `uv sync`.
 
 You now have the dependencies installed.
 
-Run `make help` to see all the available actions!
+Run `uvx --from taskipy task --list` to see all the available tasks!
 {% if include_notebooks %}
 
 ## Notebooks
@@ -90,7 +90,7 @@ git checkout main
 git pull
 uvx --from taskipy task changelog      # auto-update CHANGELOG.md
 # review CHANGELOG.md and edit if needed
-# update __version__ in src/{{ python_package_import_name }}/__init__.py
+# update __version__ in src/{{ python_package_import_name }}/__init__.py (hatch reads version from here)
 git add .
 git commit -m "chore: Release version X.Y.Z"
 git push


### PR DESCRIPTION
## Summary

This PR modernizes the copier-uv template with AI-native development features, interactive notebooks, and simplified task management. The changes replace legacy tooling (duty, make scripts, mypy) with contemporary alternatives while maintaining project quality standards.

## Key Changes

### AI Assistant Integration
- Add `CLAUDE.md` guidance files for both the template and generated projects
- Add `.cursorrules` symlink to `CLAUDE.md` for Cursor IDE integration
- Add Claude Code skills directory with specialized skills for:
  - Code review (`review`)
  - Testing (`test`)
  - Code formatting/linting (`fix`)
  - Git commits (`commit`)
  - Pull requests (`pr`)
  - marimo notebook creation (`marimo-notebook`, `jupyter-to-marimo`)

### Interactive Notebooks (Optional)
- Add marimo notebook support with starter template and comprehensive README
- Include `notebooks/` directory with example starter notebook
- Add marimo-specific documentation page
- Add `.gitignore` for notebooks directory

### Task Management
- Replace duty-based task system with taskipy via uvx
- Add `.pre-commit-config.yaml` with local uvx-based hooks
- Update all documentation and CI workflows to use `uvx --from taskipy task` commands
- Remove `scripts/make` and `duties.py`
- Remove `Makefile` (direnv-based)

### Project Structure Improvements
- Reorganize package structure with `_internal/` module for implementation details
- Move CLI implementation to `_internal/cli.py`
- Add `_internal/logging.py` with loguru configuration
- Add `_internal/debug.py` for debug utilities
- Update `__init__.py` to export public API
- Add `__main__.py` for module entry point

### Build System Updates
- Switch from pdm-backend to hatchling
- Update version management to use `__version__` in `__init__.py` (read by hatch)
- Simplify `pyproject.toml` with single Python version requirement
- Add loguru as core dependency

### Documentation & Configuration
- Remove Code of Conduct (simplified)
- Add VSCode/Cursor settings and tasks configuration
- Update CI workflow to single Python version testing
- Simplify GitHub Actions workflows
- Update contributing guidelines with new task commands
- Add comprehensive CLAUDE.md for template maintainers

### Testing
- Rename `test_cli.py` to `test_main.py` with simplified entry point testing
- Remove `test_api.py` (griffe-based API validation)
- Update test fixtures and configuration

## Implementation Details

- All generated projects now include pre-commit hooks configured via uvx
- marimo notebooks are optional (controlled by `include_notebooks` flag)
- Task commands use `uvx --from taskipy task <name>` for zero-install experience
- Claude skills provide structured guidance for AI assistants working on generated projects
- Logging is centralized through loguru with JSON output support
- Public API is explicitly managed through `__init__.py` exports