### PR TITLE
fix: Default repository provider to github.com without prompting

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -49,10 +49,9 @@ author_username:
 
 repository_provider:
   type: str
-  help: Your repository provider
+  help: Your repository provider (defaults to github.com)
   default: github.com
-  choices:
-  - github.com
+  when: false
 
 repository_namespace:
   type: str


### PR DESCRIPTION
## Summary
- Removes the single-item `choices` list from `repository_provider` in `copier.yml`
- Adds `when: false` so the question is never prompted interactively
- The default value `github.com` is always applied automatically

Closes #46

## Test plan
- [ ] Run `copier copy --trust --vcs-ref HEAD . /tmp/test-project` and verify `repository_provider` is not prompted and defaults to `github.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)