### PR TITLE
fix(docs): Add --vcs-ref HEAD to copier copy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Make sure all the [requirements](https://oedokumaci.github.io/copier-uv/requirements) are met, then:
 
 ```bash
-uvx --with copier-templates-extensions copier copy --trust "gh:oedokumaci/copier-uv" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust --vcs-ref HEAD "gh:oedokumaci/copier-uv" /path/to/your/new/project
 ```
 
 See the [documentation](https://oedokumaci.github.io/copier-uv) for more details.

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -3,7 +3,7 @@
 To generate a project, run the following command:
 
 ```bash
-uvx --with copier-templates-extensions copier copy --trust "gh:oedokumaci/copier-uv" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust --vcs-ref HEAD "gh:oedokumaci/copier-uv" /path/to/your/new/project
 ```
 
 ## Questions

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,5 +22,5 @@ uv python install 3.X  # Replace X with your desired version, e.g., 3.12
 Then generate a project with:
 
 ```bash
-uvx --with copier-templates-extensions copier copy --trust "gh:oedokumaci/copier-uv" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust --vcs-ref HEAD "gh:oedokumaci/copier-uv" /path/to/your/new/project
 ```


### PR DESCRIPTION
## Summary
- Adds `--vcs-ref HEAD` to all `copier copy` commands in `README.md`, `docs/generate.md`, and `docs/requirements.md`
- This ensures users always get the latest template version instead of a cached/older ref

Closes #45

## Test plan
- [ ] Verify the updated commands in README.md, docs/generate.md, and docs/requirements.md include `--vcs-ref HEAD`
- [ ] Confirm `copier copy --trust --vcs-ref HEAD "gh:oedokumaci/copier-uv" /tmp/test` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)