### PR TITLE
feat: Add uv sync to copier post-generation tasks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -18,6 +18,8 @@ _skip_if_exists:
 _tasks:
 - "echo 'Initializing git repository...'"
 - "git init ."
+- "echo 'Installing dependencies...'"
+- "uv sync"
 - "echo 'Installing pre-commit hooks...'"
 - "uvx pre-commit install"
 - "echo ''"
@@ -66,7 +68,7 @@ repository_name:
 
 copyright_holder:
   type: str
-  help: The name of the person/entity holding the copyright
+  help: The name of the person/entity holding the copyright (your name or company/organization name)
   default: "{{ author_fullname }}"
 
 copyright_holder_email:


### PR DESCRIPTION
## Summary
- Adds `uv sync` to the `_tasks` section in `copier.yml` so that dependencies are installed during project generation
- Runs after `git init` and before `pre-commit install`, ensuring the virtual environment exists when pre-commit hooks are set up
- Includes an "Installing dependencies..." echo message for user feedback

Closes #48

## Test plan
- [ ] Run `copier copy --trust --vcs-ref HEAD . /tmp/test-project` and verify `uv sync` runs successfully after `git init`
- [ ] Verify pre-commit hooks are installed correctly (they depend on the venv created by `uv sync`)
- [ ] Verify the full post-generation output shows the new "Installing dependencies..." message

🤖 Generated with [Claude Code](https://claude.com/claude-code)