### PR TITLE
fix: Improve copyright holder help text to suggest company names

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -66,7 +66,7 @@ repository_name:
 
 copyright_holder:
   type: str
-  help: The name of the person/entity holding the copyright
+  help: The name of the person/entity holding the copyright (your name or company/organization name)
   default: "{{ author_fullname }}"
 
 copyright_holder_email:


### PR DESCRIPTION
## Summary
- Updated the `copyright_holder` help text in `copier.yml` to clarify that it can be a company or organization name, not just a person's name
- The default value (`{{ author_fullname }}`) is kept as a sensible starting point, but the help text now reads: "The name of the person/entity holding the copyright (your name or company/organization name)"

Closes #49

## Test plan
- [ ] Run `copier copy --trust --vcs-ref HEAD . /tmp/test-project` and verify the updated help text appears for the `copyright_holder` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)