### PR TITLE
fix: Replace make references with taskipy commands in README.md.jinja

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -32,7 +32,7 @@ pip install git+https://{{ repository_provider }}/{{ repository_namespace }}/{{ 
 ```bash
 git clone https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}
 cd {{ repository_name }}
-make setup
+uv sync
 ```
 
 ### Development Cycle
@@ -61,9 +61,9 @@ make setup
 4. **Run quality checks**
 
     ```bash
-    make format  # Auto-format code
-    make check   # Run all quality checks (lint, types, docs, API)
-    make test    # Run test suite
+    uvx --from taskipy task format  # Auto-format code
+    uvx --from taskipy task ci      # Run all quality checks (format, lint, types, test)
+    uvx --from taskipy task test    # Run test suite only
     ```
 
 5. **Open a Pull Request** — prefer **rebase merge** to keep a clean history
@@ -76,12 +76,11 @@ After merging PRs:
 git switch main
 git pull
 
-make changelog   # Update CHANGELOG.md with new entries
-make coverage    # Generate coverage report
+uvx --from taskipy task changelog   # Update CHANGELOG.md with new entries
 
 # Check the changelog for the new version (x.y.z), then:
-make release version=x.y.z
+uvx --from taskipy task release -- x.y.z
 
 # Verify the updated documentation locally:
-make docs
+uvx --from taskipy task docs
 ```


### PR DESCRIPTION
## Summary

- Replaced all `make` command references in `project/README.md.jinja` with their taskipy equivalents
- `make setup` -> `uv sync`
- `make format/check/test` -> `uvx --from taskipy task format/ci/test`
- `make changelog/release/docs` -> `uvx --from taskipy task changelog/release/docs`
- Removed `make coverage` (coverage is already included in the `test` task)

Closes #57

## Test plan

- [ ] Generate a project with `copier copy --trust --vcs-ref HEAD . /tmp/test-project` and verify README.md contains correct taskipy commands
- [ ] Verify no `make` references remain in the generated README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>