### PR TITLE
feat: Add version reminder echo to changelog task

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -99,7 +99,7 @@ docs = { cmd = "uv run zensical serve", help = "Serve documentation locally" }
 docs_build = { cmd = "uv run zensical build --clean --strict", help = "Build documentation (strict)" }
 
 # Release
-changelog = { cmd = "uvx --with 'packaging<26' git-changelog --bump auto", help = "Update changelog" }
+changelog = { cmd = "uvx --with 'packaging<26' git-changelog --bump auto && echo '\nRemember to update __version__ in src/{{ python_package_import_name }}/__init__.py'", help = "Update changelog" }
 
 # Utilities
 clean = { cmd = "rm -rf build dist htmlcov site .coverage* .pytest_cache .ruff_cache __pycache__ .venvs .venv", help = "Delete build artifacts and caches" }


### PR DESCRIPTION
## Summary

- After running the `changelog` taskipy task, echo a reminder to update `__version__` in `src/<package>/__init__.py`
- The reminder uses the `{{ python_package_import_name }}` template variable so it renders with the correct package name in generated projects

Closes #51

## Test plan

- [ ] Generate a test project with `copier copy --trust --vcs-ref HEAD . /tmp/test-project`
- [ ] Verify the changelog task in the generated `pyproject.toml` includes the echo reminder
- [ ] Run the changelog task to confirm the reminder message prints after git-changelog completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)