### PR TITLE
docs: Add copier update command to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ uvx --with copier-templates-extensions copier copy --trust "gh:oedokumaci/copier
 
 See the [documentation](https://oedokumaci.github.io/copier-uv) for more details.
 
+### Updating an existing project
+
+To pull in the latest template changes to an already-generated project:
+
+```bash
+uvx --with copier-templates-extensions copier update --trust --vcs-ref HEAD --defaults
+```
+
+See the [update documentation](https://oedokumaci.github.io/copier-uv/update) for details.
+
 ## Acknowledgements
 
 This project is based on [copier-uv](https://github.com/pawamoy/copier-uv) by [Timothée Mazzucotelli (pawamoy)](https://pawamoy.github.io/).

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -239,3 +239,5 @@ Run `uvx --from taskipy task --list` to show the available tasks.
 ```
 
 The project includes an initialized git repository. See the next chapter to learn how to work on this new project.
+
+Once the template evolves with new features or fixes, you can pull those changes into your project. See [Updating a project](update.md) for the update command.

--- a/docs/update.md
+++ b/docs/update.md
@@ -4,9 +4,25 @@ Copier has an "update" feature. It means that, once a project is generated, you 
 
 It's particularly useful when you manage a lot of projects, all generated from the same template, and you want to apply a change to all your projects.
 
-Example: the template fixed a bug in the Makefile. You don't want to apply it manually to your projects.
+Example: the template fixed a bug in a configuration file. You don't want to apply it manually to your projects.
 
-To update your project, go into its directory, and run `uvx --with copier-templates-extensions copier update`. Your repository must be clean (no modified files) when running this command.
+## Update command
+
+To update your project, go into its directory and run:
+
+```bash
+uvx --with copier-templates-extensions copier update --trust --vcs-ref HEAD --defaults
+```
+
+Your repository must be clean (no modified files) when running this command.
+
+**Flags explained:**
+
+- `--trust`: Allow the template to run tasks (required for post-update hooks).
+- `--vcs-ref HEAD`: Use the latest version of the template from the main branch.
+- `--defaults`: Accept all previous answers without prompting. Remove this flag if you want to review and change your answers.
+
+## How it works
 
 Copier will use the previous answers you gave when generating the project, to re-generate it in a temporary directory, compare the two versions, and apply patches to your documents. When it's not sure, or when there's a conflict, it will ask you if you want to skip that change or force it. Your previous answers are stored in the `.copier-answers.yml` file at the root of the project directory:
 
@@ -39,6 +55,6 @@ repository_namespace: your-username
 repository_provider: github.com
 ```
 
-If you want to use all previous answers without copier prompting you for each answer, run `uvx --with copier-templates-extensions copier update --force`.
+## Reviewing changes
 
 Since we are generally using Git in our projects, my recommendation is to not think at all and blindly apply every change Copier proposes. Indeed, you'll be able to see the diff with `git diff`, un-apply changes on whole files with `git checkout -- FILE` if they are not relevant, or do partial, interactive commits with `git add -p` or within your IDE interface (PyCharm and VSCode have good support and UX for selecting and committing changes).


### PR DESCRIPTION
## Summary
- Add the full `copier update` command (`uvx --with copier-templates-extensions copier update --trust --vcs-ref HEAD --defaults`) prominently to `docs/update.md` with a dedicated "Update command" section and flag explanations
- Add cross-reference to the update docs from `docs/generate.md`
- Add "Updating an existing project" section to `README.md` with the command and link to full docs

## Test plan
- [ ] Verify `docs/update.md` renders correctly with the new sections
- [ ] Verify cross-references from `docs/generate.md` and `README.md` link correctly

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)