### PR TITLE
fix: Replace remaining make references with taskipy commands

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -32,7 +32,7 @@ pip install git+https://{{ repository_provider }}/{{ repository_namespace }}/{{ 
 ```bash
 git clone https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}
 cd {{ repository_name }}
-make setup
+uvx --from taskipy task setup
 ```
 
 ### Development Cycle
@@ -61,9 +61,9 @@ make setup
 4. **Run quality checks**
 
     ```bash
-    make format  # Auto-format code
-    make check   # Run all quality checks (lint, types, docs, API)
-    make test    # Run test suite
+    uvx --from taskipy task format  # Auto-format code
+    uvx --from taskipy task ci      # Run all quality checks (lint, types, docs)
+    uvx --from taskipy task test    # Run test suite
     ```
 
 5. **Open a Pull Request** — prefer **rebase merge** to keep a clean history
@@ -76,12 +76,18 @@ After merging PRs:
 git switch main
 git pull
 
-make changelog   # Update CHANGELOG.md with new entries
-make coverage    # Generate coverage report
+uvx --from taskipy task changelog      # Update CHANGELOG.md with new entries
+uvx --from taskipy task test           # Run tests with coverage report
 
-# Check the changelog for the new version (x.y.z), then:
-make release version=x.y.z
+# Review CHANGELOG.md and edit if needed
+# Update __version__ in src/{{ python_package_import_name }}/__init__.py
+git add .
+git commit -m "chore: Release version x.y.z"
+git push
+git tag vx.y.z
+git push --tags
+gh release create vx.y.z --generate-notes
 
 # Verify the updated documentation locally:
-make docs
+uvx --from taskipy task docs
 ```

--- a/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
+++ b/project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja
@@ -20,7 +20,7 @@ marimo is a **reactive Python notebook** that solves the problems of traditional
 
 ### Installation
 
-marimo is installed automatically when you run `make setup`. To install manually:
+marimo is installed automatically when you run `uvx --from taskipy task setup`. To install manually:
 
 ```bash
 uv pip install "marimo[recommended]"


### PR DESCRIPTION
## Summary

- Replace all `make` command references with `uvx --from taskipy task` equivalents in `project/README.md.jinja`
- Replace `make setup` reference in `project/{% if include_notebooks %}notebooks{% endif %}/README.md.jinja`
- Expand the release section in README template to include explicit git tag and `gh release` steps, matching the workflow already documented in `CONTRIBUTING.md.jinja`

## Changes

| Old command | New command |
|---|---|
| `make setup` | `uvx --from taskipy task setup` |
| `make format` | `uvx --from taskipy task format` |
| `make check` | `uvx --from taskipy task ci` |
| `make test` | `uvx --from taskipy task test` |
| `make changelog` | `uvx --from taskipy task changelog` |
| `make coverage` | `uvx --from taskipy task test` (includes coverage) |
| `make release version=x.y.z` | Explicit git tag + gh release workflow |
| `make docs` | `uvx --from taskipy task docs` |

Closes #53
Closes #57

## Test plan

- [ ] Verify no remaining `make` command references in `project/README.md.jinja`
- [ ] Verify no remaining `make` command references in notebooks README template
- [ ] Generate a test project with `copier copy --trust --vcs-ref HEAD . /tmp/test-project` and confirm README has correct taskipy commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)