### PR TITLE
feat: Add pre-commit convenience task to pyproject.toml

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -102,6 +102,7 @@ docs_build = { cmd = "uv run zensical build --clean --strict", help = "Build doc
 changelog = { cmd = "uvx --with 'packaging<26' git-changelog --bump auto", help = "Update changelog" }
 
 # Utilities
+pre_commit = { cmd = "uvx pre-commit run --all-files", help = "Run all pre-commit hooks" }
 clean = { cmd = "rm -rf build dist htmlcov site .coverage* .pytest_cache .ruff_cache __pycache__ .venvs .venv", help = "Delete build artifacts and caches" }
 
 # Profiling (using module variable)


### PR DESCRIPTION
## Summary
- Adds a `pre_commit` taskipy task that runs `uvx pre-commit run --all-files`
- Placed in the Utilities section of `[tool.taskipy.tasks]`

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)