### PR TITLE
fix(docs): Document copier ref caching workaround

### DIFF
--- a/docs/generate.md
+++ b/docs/generate.md
@@ -6,6 +6,17 @@ To generate a project, run the following command:
 uvx --with copier-templates-extensions copier copy --trust "gh:oedokumaci/copier-uv" /path/to/your/new/project
 ```
 
+!!! warning "Stale template versions"
+    Copier caches Git refs and may fetch an older version of the template instead of the latest release. If you are not getting the version you expect, pin the ref explicitly:
+
+    ```bash
+    # Latest commit on the default branch
+    uvx --with copier-templates-extensions copier copy --trust --vcs-ref HEAD "gh:oedokumaci/copier-uv" /path/to/project
+
+    # Specific release tag
+    uvx --with copier-templates-extensions copier copy --trust --vcs-ref v0.7.0 "gh:oedokumaci/copier-uv" /path/to/project
+    ```
+
 ## Questions
 
 *The following examples are not up-to-date, they simply illustrate how the template works.*

--- a/docs/update.md
+++ b/docs/update.md
@@ -8,6 +8,9 @@ Example: the template fixed a bug in the Makefile. You don't want to apply it ma
 
 To update your project, go into its directory, and run `uvx --with copier-templates-extensions copier update`. Your repository must be clean (no modified files) when running this command.
 
+!!! warning "Stale template versions"
+    Copier caches Git refs and may fetch an older version of the template. If the update does not pick up the latest release, pin the ref explicitly with `--vcs-ref HEAD` or `--vcs-ref TAG` (e.g. `--vcs-ref v0.7.0`).
+
 Copier will use the previous answers you gave when generating the project, to re-generate it in a temporary directory, compare the two versions, and apply patches to your documents. When it's not sure, or when there's a conflict, it will ask you if you want to skip that change or force it. Your previous answers are stored in the `.copier-answers.yml` file at the root of the project directory:
 
 ```


### PR DESCRIPTION
## Summary
- Adds a warning admonition to `docs/generate.md` explaining that copier caches Git refs and may fetch stale template versions, with `--vcs-ref` examples
- Adds a matching warning note to `docs/update.md` for the update workflow

Closes #55

## Test plan
- [ ] Verify the admonition renders correctly with `mkdocs serve`
- [ ] Confirm the `--vcs-ref` commands shown in the examples work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)