### PR TITLE
feat(cursor): Complete .cursor/ directory with rules and skills symlinking

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,6 @@
+---
+description: Project instructions and AI guidance for the copier-uv template repository
+alwaysApply: true
+---
+
+@CLAUDE.md

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An AI-native [Copier](https://github.com/copier-org/copier) template for Python 
 ## Features
 
 - **Claude Code integration** -- every generated project includes a `CLAUDE.md` with project-aware guidance and custom skills (`/commit`, `/release`, `/review-pr`, `/docs-deploy`) so AI assistants understand your codebase from day one
-- **Cursor IDE support** -- `.cursorrules` symlink to `CLAUDE.md` for seamless Cursor integration
+- **Cursor IDE support** -- full `.cursor/` directory with always-apply rules pointing to `CLAUDE.md` and skills symlinked from `.claude/skills/`, so Claude Code and Cursor share the same AI context
 - **Modern Python toolchain** -- [uv](https://github.com/astral-sh/uv) for dependency management, [Ruff](https://github.com/charliermarsh/ruff) for formatting and linting, [ty](https://github.com/astral-sh/ty) for type checking
 - **Task runner** -- [taskipy](https://github.com/taskipy/taskipy) tasks for every workflow: `fix`, `ci`, `test`, `docs`, `changelog`, `profile`, and more
 - **Pre-commit hooks** -- pre-configured Ruff formatting and linting hooks

--- a/docs/work.md
+++ b/docs/work.md
@@ -6,7 +6,13 @@ The generated project has this structure:
 📁 your_project ------------------- # your freshly created project!
 ├── 📄 CHANGELOG.md --------------- #
 ├── 📄 CLAUDE.md ------------------ # AI assistant guidance
-├── 📄 .cursorrules --------------- # symlink to CLAUDE.md (for Cursor IDE)
+├── 📁 .claude -------------------- # Claude Code configuration
+│   └── 📁 skills ----------------- # Claude Code skills (/commit, /fix, etc.)
+├── 📁 .cursor -------------------- # Cursor IDE configuration
+│   ├── 📁 rules ------------------ # Cursor rules (always-apply → CLAUDE.md)
+│   │   └── 📄 project.mdc ------- #
+│   └── 📁 skills → .claude/skills  # symlink for Cursor skill discovery
+├── 📄 .cursorrules → CLAUDE.md --- # legacy symlink (deprecated)
 ├── 📄 .pre-commit-config.yaml ---- # pre-commit hooks configuration
 ├── 📁 config --------------------- # tools configuration files
 │   ├── 📄 coverage.ini ----------- #
@@ -50,6 +56,24 @@ The generated project has this structure:
     ├── 📄 __init__.py ------------ #
     └── 📄 test_main.py ----------- # tests for main entry point
 ```
+
+## AI Integration
+
+Every generated project ships with first-class support for **Claude Code** and **Cursor IDE**. A single `CLAUDE.md` file serves as the source of truth for AI context, with both tools configured to read from it automatically.
+
+### Claude Code
+
+- **`CLAUDE.md`** — project-aware guidance loaded automatically by Claude Code
+- **`.claude/skills/`** — custom skills invokable with `/commit`, `/fix`, `/test`, `/pr`, `/release`, `/review`
+
+### Cursor IDE
+
+- **`.cursor/rules/project.mdc`** — always-apply rule that references `CLAUDE.md` via `@CLAUDE.md`
+- **`.cursor/skills/`** — symlink to `.claude/skills/` so Cursor discovers the same skills
+- **`.cursorrules`** — legacy symlink to `CLAUDE.md` (deprecated, kept for backward compatibility)
+- **`config/vscode/`** — shared VSCode/Cursor settings (formatter, linter, debug configs)
+
+This means you maintain one set of AI instructions (`CLAUDE.md` + `.claude/skills/`) and both Claude Code and Cursor use them seamlessly.
 
 ## Environment
 

--- a/project/.cursor/rules/project.mdc
+++ b/project/.cursor/rules/project.mdc
@@ -1,0 +1,6 @@
+---
+description: Project instructions and AI guidance
+alwaysApply: true
+---
+
+@CLAUDE.md

--- a/project/.cursor/skills
+++ b/project/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/project/CLAUDE.md.jinja
+++ b/project/CLAUDE.md.jinja
@@ -80,7 +80,8 @@ if TYPE_CHECKING:
 
 ```
 {{ repository_name }}/
-├── .claude/skills/       # Claude Code skills
+├── .claude/skills/       # Claude Code skills (/commit, /fix, /test, etc.)
+├── .cursor/              # Cursor IDE (rules → CLAUDE.md, skills → .claude/skills)
 ├── src/{{ python_package_import_name }}/
 │   ├── __init__.py       # Public API
 │   ├── __main__.py       # Module entry point (run via `task run`)
@@ -124,7 +125,7 @@ Example: `configure_logging(level="INFO", json_logs=False)`
 
 ## Skills
 
-Claude Code skills are available in `.claude/skills/`. Invoke with `/skill-name`:
+Skills are available in `.claude/skills/` (also symlinked at `.cursor/skills/` for Cursor IDE). Invoke with `/skill-name`:
 
 | Skill | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

- Add modern `.cursor/rules/project.mdc` with `alwaysApply: true` referencing `CLAUDE.md` via `@CLAUDE.md` directive
- Add `.cursor/skills/` as symlink to `.claude/skills/` for Cursor skill discovery
- Both template repo and generated projects get the full `.cursor/` setup
- Updated docs with AI Integration section explaining the Claude Code + Cursor dual setup
- Legacy `.cursorrules` symlink kept for backward compatibility

Closes #86

## Test plan

- [ ] Verify `.cursor/rules/project.mdc` is copied to generated projects
- [ ] Verify `.cursor/skills` symlink resolves correctly in generated projects
- [ ] Open generated project in Cursor and confirm rules are loaded
- [ ] Verify `/commit`, `/fix`, `/test` skills are discoverable in Cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)